### PR TITLE
Update p2000.py

### DIFF
--- a/p2000.py
+++ b/p2000.py
@@ -490,7 +490,7 @@ class Main:
                                     regex_plaatsnamen_strip = rf"\w*.[a-z|A-Z] \b{plaatsnaam}\b"
                                     plaatsnamen_strip = re.search(regex_plaatsnamen_strip, strip)
                                     if self.debug:
-                                        print("What and where is there an possible adress match? " + plaatsnamen_strip)
+                                        print(plaatsnamen_strip)
                                     if plaatsnamen_strip:
                                         addr = plaatsnamen_strip.group(0)
                                         # Final non address symbols strip


### PR DESCRIPTION
440-446 Added a removal of the upppercase city, due to double in the postcode message
463 variable afkorting is alreade the result of the regex, can be re-used
468-502 added a way to strip down the message from technical info and keep the portion that probable has an adress and find that adress to find a city from the city list and first word left of the city, it works for 85% of the messages without other address findings.