### PR TITLE
Added exception clause to prevent MQTT hang

### DIFF
--- a/p2000.py
+++ b/p2000.py
@@ -689,6 +689,8 @@ class Main:
                             f"MQTT status: Posting to {self.mqtt_server}:{self.mqtt_port} topic:{self.mqtt_topic}"
                         )
                         self.logger.debug(f"MQTT json: {data}")
+                    except Exception as e:
+                        self.logger.debug(f"MQTT Crashed: {e}")
                     finally:
                         # Mark as posted to prevent race conditions
                         msg.is_posted = True


### PR DESCRIPTION
After using MQTT for a while, when an error occured the P2000.py script failed. Apparently no retries where made on the mqtt routine, after a fail. Adding an exception statement catches the error and prevents the program from hanging.

